### PR TITLE
Fix having multiple bodies in Component

### DIFF
--- a/elmer_circuitbuilder/elmer_circuitbuilder.py
+++ b/elmer_circuitbuilder/elmer_circuitbuilder.py
@@ -1862,7 +1862,7 @@ def write_sif_additions(c, source_vector, ofile):
                 joined_str_master_names = ", ".join(str_mbody)
                 print("  Master Bodies Name = " + str(joined_str_master_names), file=elmer_file)
             if(int_mbody):
-                joined_str_master_bodies = ", ".join(int_mbody)
+                joined_str_master_bodies = " ".join(int_mbody)
                 print("  Master Bodies(" + str(int_mb_count) + ") = " +
                       str(joined_str_master_bodies) , file=elmer_file)
             # ------------------------------------------------------------------------------


### PR DESCRIPTION
If one component contains multiple bodies, the list of body IDs is currently comma separated. This raises the following error when running ElmerSolver: `ERROR:: SectionContents: Non-numeric characters for integer 1 for keyword "master bodies"`

Changing this to be space separated resolves this issue.

I assume the same applies to `Master Bodies Name`, but I haven't managed to figure out how to use it, so I've left it for now. Happy to include this in this PR if someone can confirm this needs changing as well.