### PR TITLE
Close file

### DIFF
--- a/elmer_circuitbuilder/elmer_circuitbuilder.py
+++ b/elmer_circuitbuilder/elmer_circuitbuilder.py
@@ -2006,7 +2006,7 @@ def write_parameters(c, ofile):
                       , file=elmer_file)
     print("", file=elmer_file)
 
-    elmer_file.close
+    elmer_file.close()
 
 
 def write_elmer_circuit_file(c, elmerA, elmerB, elmersource, unknown_names, num_nodes, num_edges, ofile):


### PR DESCRIPTION
One of the `elmer_file.close()` calls is missing the parentheses, so the file isn't actually closed.